### PR TITLE
AutoPickupTweaksTweaks

### DIFF
--- a/AutoPickupTweaks/__init__.py
+++ b/AutoPickupTweaks/__init__.py
@@ -178,7 +178,7 @@ def InteractParticles(caller: UObject, function: UFunction, params: FStruct):
 
 def UsedBy(caller: UObject, function: UFunction, params: FStruct):
     # Check PlayerInteractionDistance 350 plus a bit for auto pickup on open
-    if Distance(params.User.Location, caller.Location) <= 400:
+    if params.User and Distance(params.User.Location, caller.Location) <= 400:
         APT.InteractiveObjects[caller.ConsumerHandle.PID] = [params.User.Controller]
     else:
         # Set None for us the check the opened IO but not link to a PC for initial open
@@ -203,7 +203,7 @@ def HandlePickupQuery(caller: unrealsdk.UObject, function: unrealsdk.UFunction, 
     """
     Pickup = caller.Base
     if Pickup.Class.Name == "WillowPickup" and params.Other.Class.Name == "WillowPlayerPawn":
-        if Pickup.Base:
+        if Pickup.Base and Pickup.Base.ConsumerHandle:
             BaseIO = Pickup.Base.ConsumerHandle.PID
             # Only if NO player has dibsed this - so an already opened chest
             if BaseIO in APT.InteractiveObjects.keys() and not APT.InteractiveObjects[BaseIO] and Pickup.bPickupable:
@@ -218,7 +218,7 @@ def SawPickupable(caller: unrealsdk.UObject, function: unrealsdk.UFunction, para
     if not params.Pickup or not params.Pickup.ObjectPointer:
         return True
     Pickup = params.Pickup.ObjectPointer
-    if Pickup.Base:
+    if Pickup.Base and Pickup.Base.ConsumerHandle:
         BaseIO = Pickup.Base.ConsumerHandle.PID
         # Only if NO player has dibsed this - so an already opened chest
         if BaseIO in APT.InteractiveObjects.keys() and not APT.InteractiveObjects[BaseIO] and Pickup.bPickupable:


### PR DESCRIPTION
Hey up, thanks for the mod.
I don't know if you care about adding to this, but I edited this to add some options and make it more compatible with the Open Sesame mod, which can open chests from miles away.
Thought I'd share in case you were interested.

+ Added pickup distance options.
+ Added option for chests items only picking up when the opening animation finishes, so you get a chance to see the items.
+ Prevent "FULL" HUD icon appearing with Chest Items enabled.
+ Chest Items checks whether the player is in interaction distance for auto-pickup, in case chests can be used from a distance.
+ Opened chests will auto pickup items in them when looking at an item in them, within range.